### PR TITLE
fix: Fix issue `Cannot find 'TARGET_IPHONE_SIMULATOR'`

### DIFF
--- a/ios/Classes/YandexMapController.swift
+++ b/ios/Classes/YandexMapController.swift
@@ -264,7 +264,11 @@ public class YandexMapController:
   }
 
   private static func isM1Simulator() -> Bool {
-    return (TARGET_IPHONE_SIMULATOR & TARGET_CPU_ARM64) != 0
+    #if targetEnvironment(simulator) && arch(arm64)
+    return true
+    #else
+    return false
+    #endif
   }
 
   private func hasLocationPermission() -> Bool {


### PR DESCRIPTION
FIx issue: https://github.com/surfstudio/yandex-mapkit-lite-flutter/issues/25

